### PR TITLE
update to SDK 4.12.1, add version note in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ We've built a simple console application that demonstrates how LaunchDarkly's SD
 1. Make sure you have [Maven](https://maven.apache.org/download.cgi) installed. We've tested against Maven 3
 2. Create a new project
 3. Copy your SDK key and feature flag key from your LaunchDarkly dashboard into `main` 
-4. Run `mvn clean compile assembly:single`
-5. Then run `java -jar target/hello-java-1.0-SNAPSHOT-jar-with-dependencies.jar`
+4. Make sure `pom.xml` is referencing the latest version of `launchdarkly-java-server-sdk`; you can see the latest release [here](https://github.com/launchdarkly/java-server-sdk/releases)
+5. Run `mvn clean compile assembly:single`
+6. Then run `java -jar target/hello-java-1.0-SNAPSHOT-jar-with-dependencies.jar`

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,14 @@
         <dependency>
             <groupId>com.launchdarkly</groupId>
             <artifactId>launchdarkly-java-server-sdk</artifactId>
-            <version>[4.8.0,5.0.0)</version>
+            <version>4.12.1</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.14</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
     <properties>


### PR DESCRIPTION
See: https://github.com/launchdarkly/hello-java/issues/5

I think the real solution for this will be to move to Gradle. Maven doesn't have a "use latest compatible version" syntax; the closest you can get is to use the versions plugin and change the Maven command line to add `versions:use-latest-releases` before `compile`, but I've found that it doesn't work correctly— it selected 4.11.1 even though the latest release is 4.12.1 (possibly because there was a 4.12.0-SNAPSHOT version in between, but that's just a guess).