### PR TITLE
update to use SDK 5 (prerelease)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We've built a simple console application that demonstrates how LaunchDarkly's SD
 
 ## Build instructions 
 
-This project uses [Gradle](https://gradle.org/). It requires that Java is already installed on your system (version 7 or higher). It will automatically use the latest release of the LaunchDarkly SDK with major version 4.
+This project uses [Gradle](https://gradle.org/). It requires that Java is already installed on your system (version 8 or higher). It will automatically use the latest release of the LaunchDarkly SDK with major version 5.
 
 1. Edit `src/main/java/Hello.java` and set the value of `SDK_KEY` to your LaunchDarkly SDK key. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set `FEATURE_FLAG_KEY` to the flag key.
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,13 @@ plugins {
 
 repositories {
     mavenCentral()
+    // Before LaunchDarkly release artifacts get synced to Maven Central they are here along with snapshots:
+    maven { url "https://oss.sonatype.org/content/groups/public/" }
 }
 
 allprojects {
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }
 
 application {
@@ -18,7 +20,7 @@ application {
 }
 
 ext.versions = [
-    "sdk": "4.+", // will use the latest 4.x version
+    "sdk": "5.0.0-SNAPSHOT",
     "slf4j": "1.7.22"
 ]
 

--- a/src/main/java/Hello.java
+++ b/src/main/java/Hello.java
@@ -1,6 +1,6 @@
-import com.launchdarkly.client.LDClient;
-import com.launchdarkly.client.LDUser;
-import com.launchdarkly.client.value.LDValue;
+import com.launchdarkly.sdk.LDUser;
+import com.launchdarkly.sdk.LDValue;
+import com.launchdarkly.sdk.server.LDClient;
 
 import java.io.IOException;
 


### PR DESCRIPTION
This currently uses the latest 5.0.0-SNAPSHOT build. I've targeted it to a feature branch so once we're ready to release 5.0, we can update the dependency to the real 5.0.0 and merge the branch.