### PR TITLE
(consideration) Remove PII from user key

### DIFF
--- a/src/main/java/Hello.java
+++ b/src/main/java/Hello.java
@@ -22,7 +22,8 @@ public class Hello {
 
     // Set up the user properties. This user should appear on your LaunchDarkly users dashboard
     // soon after you run the demo.
-    LDUser user = new LDUser.Builder("bob@example.com")
+    LDUser user = new LDUser.Builder("00000000-0000-0000-0000-000000000000")
+                            .email("bob@example.com")
                             .firstName("Bob")
                             .lastName("Loblaw")
                             .custom("groups", LDValue.buildArray().add("beta_testers").build())


### PR DESCRIPTION
Using an email as the user's key sets a poor example.
- PII should not be used as a user's key.
- A user's key should be something that doesn't change, and someone's email could change.